### PR TITLE
Support FindTarantool to look for nonsystem tarantool

### DIFF
--- a/cmake/FindTarantool.cmake
+++ b/cmake/FindTarantool.cmake
@@ -9,7 +9,8 @@ macro(extract_definition name output input)
 endmacro()
 
 find_path(TARANTOOL_INCLUDE_DIR tarantool/module.h
-        HINTS ENV TARANTOOL_DIR /usr/local/include
+        HINTS ${TARANTOOL_DIR} ENV TARANTOOL_DIR
+        PATH_SUFFIXES include
         )
 
 if(TARANTOOL_INCLUDE_DIR)


### PR DESCRIPTION
If a user have tarantool installed into custom directory he may specify
path to tarantool installation using `TARANTOOL_DIR` variable like this:

```bash
tarantoolctl rocks TARANTOOL_DIR=/path/to/tarantool/ install kafka
```

Luarocks will bypass this variable to cmake, which will use is to find
its header files