### PR TITLE
expose librdkafka version

### DIFF
--- a/kafka/common.c
+++ b/kafka/common.c
@@ -1,8 +1,5 @@
 #include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
-
-#include <tarantool/module.h>
+#include <librdkafka/rdkafka.h>
 
 #include <common.h>
 
@@ -32,4 +29,14 @@ lua_push_error(struct lua_State *L) {
     lua_pushnumber(L, -3);
     lua_insert(L, -2);
     return 2;
+}
+
+/**
+ * Push current librdkafka version
+ */
+int
+lua_librdkafka_version(struct lua_State *L) {
+	const char *version = rd_kafka_version_str();
+	lua_pushstring(L, version);
+	return 1;
 }

--- a/kafka/common.h
+++ b/kafka/common.h
@@ -24,6 +24,8 @@ int save_pushstring_wrapped(struct lua_State *L);
 
 int safe_pushstring(struct lua_State *L, char *str);
 
+int lua_librdkafka_version(struct lua_State *L);
+
 /**
  * Push native lua error with code -3
  */

--- a/kafka/init.lua
+++ b/kafka/init.lua
@@ -318,4 +318,5 @@ end
 return {
     Consumer = Consumer,
     Producer = Producer,
+    _LIBRDKAFKA = tnt_kafka.librdkafka_version(),
 }

--- a/kafka/tnt_kafka.c
+++ b/kafka/tnt_kafka.c
@@ -80,6 +80,7 @@ luaopen_kafka_tntkafka(lua_State *L) {
 	static const struct luaL_Reg meta [] = {
         {"create_consumer", lua_create_consumer},
         {"create_producer", lua_create_producer},
+        {"librdkafka_version", lua_librdkafka_version},
         {NULL, NULL}
 	};
 	luaL_register(L, NULL, meta);


### PR DESCRIPTION
For debug purposes it could be useful to know a version of
librdkafka. This patch expose _LIBRDKAFKA variable to show version of
librdkafka:

```lua
tarantool> require('kafka')._LIBRDKAFKA
---
- 1.5.3
...
```