### PR TITLE
Update consumer_msg.c

### DIFF
--- a/kafka/consumer_msg.c
+++ b/kafka/consumer_msg.c
@@ -123,7 +123,10 @@ new_consumer_msg(rd_kafka_message_t *rd_message) {
     msg->topic = rd_message->rkt;
     msg->partition = rd_message->partition;
     msg->value = NULL;
+    msg->value_len = 0;
     msg->key = NULL;
+    msg->key_len = 0;
+    msg->offset = 0;
 
     // value
     if (rd_message->len > 0) {

--- a/kafka/consumer_msg.c
+++ b/kafka/consumer_msg.c
@@ -122,6 +122,8 @@ new_consumer_msg(rd_kafka_message_t *rd_message) {
     msg = malloc(sizeof(msg_t));
     msg->topic = rd_message->rkt;
     msg->partition = rd_message->partition;
+    msg->value = NULL;
+    msg->key = NULL;
 
     // value
     if (rd_message->len > 0) {


### PR DESCRIPTION
Кафка падает при сборке мусора освобождая память из под сообщения

```
#0  0x00007f6d01923387 in raise () from /lib64/libc.so.6
#1  0x00007f6d01924a78 in abort () from /lib64/libc.so.6
#2  0x000000000056cc89 in sig_fatal_cb (signo=<optimized out>, siginfo=<optimized out>, context=<optimized out>) at /__w/sdk/sdk/tarantool-2.4/src/main.cc:301
#3  <signal handler called>
#4  0x00007f6d01972aec in free () from /lib64/libc.so.6
#5  0x00007f6cfd53a507 in destroy_consumer_msg (msg=0x7f6cb0004110) at /tmp/luarocks_kafka-1.3.0-1-PGeZjs/kafka/kafka/consumer_msg.c:152

151 if (msg->key != NULL) {
152     free(msg->key);
153 }
```

Гипотеза: такое происходит, пушо изначально сообщение аллоцировалось, но память не занулялась.

Пофикшено.  Closed #35