### PR TITLE
Add example how to build static kafka in centos 7

### DIFF
--- a/examples/static-build/Dockerfile
+++ b/examples/static-build/Dockerfile
@@ -1,0 +1,14 @@
+FROM registry.gitlab.com/runfor/envs/centos:7-build as static-kafka
+
+RUN set -x \
+    && git clone --recurse-submodules https://github.com/tarantool/kafka /opt/kafka \
+    && wget -P /etc/yum.repos.d/ https://copr.fedorainfracloud.org/coprs/bgstack15/stackrpms/repo/epel-7/bgstack15-stackrpms-epel-7.repo \
+    && yum install -y tarantool tarantool-devel openssl110
+
+WORKDIR /opt/kafka
+
+RUN tarantoolctl rocks STATIC_BUILD=ON make \
+    && tarantoolctl rocks pack kafka
+
+FROM scratch as export
+COPY --from=static-kafka /opt/kafka/kafka-scm-1.linux-x86_64.rock /

--- a/examples/static-build/README.md
+++ b/examples/static-build/README.md
@@ -1,0 +1,8 @@
+Static kafka build
+---
+
+```bash
+$ docker buildx build --target export --output rocks .
+$ ls rocks
+kafka-scm-1.linux-x86_64.rock
+```


### PR DESCRIPTION
This snippet helps builds static kafka module compatible with static tarantool build, which exports openssl 1.1 symbols