### PR TITLE
Introduce CI for kafka module

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -1,0 +1,61 @@
+name: fast_testing
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  linux:
+    # We want to run on external PRs, but not on our own internal
+    # PRs as they'll be run by the push to the branch.
+    #
+    # The main trick is described here:
+    # https://github.com/Dart-Code/Dart-Code/pull/2375
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tarantool:
+          - '2.8'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install tarantool ${{ matrix.tarantool }}
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: ${{ matrix.tarantool }}
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Clone the module
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Start Kafka
+        uses: 280780363/kafka-action@v1.0
+        with:
+          kafka version: "latest"
+          zookeeper version: "latest"
+          kafka port: 9092
+          auto create topic: "true"
+
+      - name: Install Python dependencies
+        run: pip3 install -r tests/requirements.txt
+
+      - name: Build module
+        run: tarantoolctl rocks STATIC_BUILD=ON make
+
+      - name: Run tarantool application
+        run: TT_LOG=tarantool.log tarantool tests/app.lua &
+
+      - name: Run test
+        run: KAFKA_HOST=localhost:9092 pytest tests
+
+      - name: Print Tarantool logs
+        if: always()
+        run: cat tarantool.log

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 pytest
-kafka-python==2.0.0
-aiokafka==0.7.0
-tarantool==0.6.6
+kafka-python==2.0.2
+aiokafka==0.7.2
+tarantool==0.7.1

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,9 +1,12 @@
+import os
 import time
 import asyncio
 from contextlib import contextmanager
 
 from aiokafka import AIOKafkaProducer
 import tarantool
+
+KAFKA_HOST = os.getenv("KAFKA_HOST", "kafka:9092")
 
 
 def get_server():
@@ -70,7 +73,7 @@ def test_consumer_should_consume_msgs():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_consume_msgs"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_consume_msgs"}):
         server.call("consumer.subscribe", [["test_consume"]])
 
         response = server.call("consumer.consume", [10])
@@ -103,7 +106,7 @@ def test_consumer_should_consume_msgs_from_multiple_topics():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_consume_msgs_from_multiple_topics"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_consume_msgs_from_multiple_topics"}):
         server.call("consumer.subscribe", [["test_multi_consume_1", "test_multi_consume_2"]])
 
         response = server.call("consumer.consume", [10])
@@ -135,7 +138,7 @@ def test_consumer_should_completely_unsubscribe_from_topics():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_completely_unsubscribe_from_topics"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_completely_unsubscribe_from_topics"}):
         server.call("consumer.subscribe", [["test_unsubscribe"]])
 
         response = server.call("consumer.consume", [10])
@@ -177,7 +180,7 @@ def test_consumer_should_partially_unsubscribe_from_topics():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_partially_unsubscribe_from_topics"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_partially_unsubscribe_from_topics"}):
         server.call("consumer.subscribe", [["test_unsub_partially_1", "test_unsub_partially_2"]])
 
         write_into_kafka("test_unsub_partially_1", (message1, ))
@@ -215,7 +218,7 @@ def test_consumer_should_log_errors():
 def test_consumer_should_log_debug():
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"debug": "consumer,cgrp,topic,fetch"}):
+    with create_consumer(server, KAFKA_HOST, {"debug": "consumer,cgrp,topic,fetch"}):
         time.sleep(2)
 
         response = server.call("consumer.get_logs", [])
@@ -226,12 +229,12 @@ def test_consumer_should_log_debug():
 def test_consumer_should_log_rebalances():
     server = get_server()
 
-    with create_consumer(server, "kafka:9092"):
-        time.sleep(2)
+    with create_consumer(server, KAFKA_HOST):
+        time.sleep(5)
 
         server.call("consumer.subscribe", [["test_unsub_partially_1"]])
 
-        time.sleep(10)
+        time.sleep(20)
 
         response = server.call("consumer.get_rebalances", [])
 
@@ -261,7 +264,7 @@ def test_consumer_should_continue_consuming_from_last_committed_offset():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_continue_consuming_from_last_committed_offset"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_continue_consuming_from_last_committed_offset"}):
         server.call("consumer.subscribe", [["test_consuming_from_last_committed_offset"]])
 
         write_into_kafka("test_consuming_from_last_committed_offset", (message1, ))
@@ -277,7 +280,7 @@ def test_consumer_should_continue_consuming_from_last_committed_offset():
 
     time.sleep(2)
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_continue_consuming_from_last_committed_offset"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_continue_consuming_from_last_committed_offset"}):
         server.call("consumer.subscribe", [["test_consuming_from_last_committed_offset"]])
 
         write_into_kafka("test_consuming_from_last_committed_offset", (message3, ))

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -1,8 +1,11 @@
+import os
 import time
 import asyncio
 
 from aiokafka import AIOKafkaConsumer
 import tarantool
+
+KAFKA_HOST = os.getenv("KAFKA_HOST", "kafka:9092")
 
 
 def get_server():
@@ -18,7 +21,7 @@ def get_server():
 def test_producer_should_produce_msgs():
     server = get_server()
 
-    server.call("producer.create", ["kafka:9092"])
+    server.call("producer.create", [KAFKA_HOST])
 
     server.call("producer.produce", (
         (
@@ -56,7 +59,7 @@ def test_producer_should_produce_msgs():
                 await consumer.stop()
 
         try:
-            await asyncio.wait_for(consume(), 10, loop=loop)
+            await asyncio.wait_for(consume(), 10)
         except asyncio.TimeoutError:
             pass
 
@@ -98,7 +101,7 @@ def test_producer_should_log_errors():
 def test_producer_should_log_debug():
     server = get_server()
 
-    server.call("producer.create", ["kafka:9092", {"debug": "broker,topic,msg"}])
+    server.call("producer.create", [KAFKA_HOST, {"debug": "broker,topic,msg"}])
 
     time.sleep(2)
 


### PR DESCRIPTION
This patch changes a lot of things to be able to enable tests in
CI:
  - Bump librdkafka version to v1.8.2
  - Bump python requirements versions
  - Tune timeouts in tests
  - Drop deprecated option from tests
  - Allow to pass kafka host via env variables