### PR TITLE
Introduce CI for kafka module

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -1,0 +1,61 @@
+name: fast_testing
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  linux:
+    # We want to run on external PRs, but not on our own internal
+    # PRs as they'll be run by the push to the branch.
+    #
+    # The main trick is described here:
+    # https://github.com/Dart-Code/Dart-Code/pull/2375
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tarantool:
+          - '2.8'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install tarantool ${{ matrix.tarantool }}
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: ${{ matrix.tarantool }}
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Clone the module
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Start Kafka
+        uses: 280780363/kafka-action@v1.0
+        with:
+          kafka version: "latest"
+          zookeeper version: "latest"
+          kafka port: 9092
+          auto create topic: "true"
+
+      - name: Install Python dependencies
+        run: pip3 install -r tests/requirements.txt
+
+      - name: Build module
+        run: tarantoolctl rocks STATIC_BUILD=ON make
+
+      - name: Run tarantool application
+        run: TT_LOG=tarantool.log tarantool tests/app.lua &
+
+      - name: Run test
+        run: KAFKA_HOST=localhost:9092 pytest tests
+
+      - name: Print Tarantool logs
+        if: always()
+        run: cat tarantool.log

--- a/kafka/consumer.c
+++ b/kafka/consumer.c
@@ -575,24 +575,8 @@ lua_consumer_close(struct lua_State *L) {
         return 1;
     }
 
-    rd_kafka_resp_err_t err = rd_kafka_unsubscribe((*consumer_p)->rd_consumer);
-    if (err) {
-        lua_pushnil(L);
-        const char *const_err_str = rd_kafka_err2str(err);
-        char err_str[512];
-        strncpy(err_str, const_err_str, sizeof(err_str) - 1);
-        int fail = safe_pushstring(L, err_str);
-        return fail ? lua_push_error(L): 2;
-    }
-    err = rd_kafka_commit((*consumer_p)->rd_consumer, NULL, 0); // sync commit of current offsets
-    if (err) {
-        lua_pushnil(L);
-        const char *const_err_str = rd_kafka_err2str(err);
-        char err_str[512];
-        strncpy(err_str, const_err_str, sizeof(err_str) - 1);
-        int fail = safe_pushstring(L, err_str);
-        return fail ? lua_push_error(L): 2;
-    }
+    rd_kafka_unsubscribe((*consumer_p)->rd_consumer);
+    rd_kafka_commit((*consumer_p)->rd_consumer, NULL, 0); // sync commit of current offsets
 
     // trying to close in background until success
     coio_call(wait_consumer_close, (*consumer_p)->rd_consumer);

--- a/kafka/consumer.c
+++ b/kafka/consumer.c
@@ -516,6 +516,7 @@ static ssize_t
 wait_consumer_close(va_list args) {
     rd_kafka_t *rd_consumer = va_arg(args, rd_kafka_t *);
     rd_kafka_message_t *rd_msg = NULL;
+    // cleanup consumer queue, because at other way close hangs forever
     while (true) {
         rd_msg = rd_kafka_consumer_poll(rd_consumer, 1000);
         if (rd_msg != NULL) {
@@ -575,6 +576,7 @@ lua_consumer_close(struct lua_State *L) {
         return 1;
     }
 
+    // unsubscribe consumer to make possible close it
     rd_kafka_unsubscribe((*consumer_p)->rd_consumer);
     rd_kafka_commit((*consumer_p)->rd_consumer, NULL, 0); // sync commit of current offsets
 

--- a/kafka/consumer.c
+++ b/kafka/consumer.c
@@ -579,13 +579,7 @@ lua_consumer_close(struct lua_State *L) {
     rd_kafka_commit((*consumer_p)->rd_consumer, NULL, 0); // sync commit of current offsets
 
     // trying to close in background until success
-    int attempts = 5;
-    while (coio_call(wait_consumer_close, (*consumer_p)->rd_consumer) == -1) {
-        // FIXME: maybe send errors to error queue?
-        attempts -= 1;
-        if (attempts == 0) 
-            break;
-    }
+    coio_call(wait_consumer_close, (*consumer_p)->rd_consumer);
     lua_pushboolean(L, 1);
     return 1;
 }

--- a/kafka/consumer.c
+++ b/kafka/consumer.c
@@ -570,7 +570,7 @@ lua_consumer_close(struct lua_State *L) {
     rd_kafka_unsubscribe((*consumer_p)->rd_consumer);
 
     // trying to close in background until success
-    int attempts = 5
+    int attempts = 5;
     while (coio_call(wait_consumer_close, (*consumer_p)->rd_consumer) == -1) {
         // FIXME: maybe send errors to error queue?
         attempts -= 1;

--- a/kafka/consumer.c
+++ b/kafka/consumer.c
@@ -157,7 +157,7 @@ lua_consumer_subscribe(struct lua_State *L) {
     if (err) {
         const char *const_err_str = rd_kafka_err2str(err);
         char err_str[512];
-        strncpy(err_str, const_err_str, 512);
+        strncpy(err_str, const_err_str, sizeof(err_str)-1);
         int fail = safe_pushstring(L, err_str);
         return fail ? lua_push_error(L): 1;
     }
@@ -195,7 +195,7 @@ lua_consumer_unsubscribe(struct lua_State *L) {
         if (err) {
             const char *const_err_str = rd_kafka_err2str(err);
             char err_str[512];
-            strncpy(err_str, const_err_str, 512);
+            strncpy(err_str, const_err_str, sizeof(err_str)-1);
             int fail = safe_pushstring(L, err_str);
             return fail ? lua_push_error(L): 1;
         }
@@ -204,7 +204,7 @@ lua_consumer_unsubscribe(struct lua_State *L) {
         if (err) {
             const char *const_err_str = rd_kafka_err2str(err);
             char err_str[512];
-            strncpy(err_str, const_err_str, 512);
+            strncpy(err_str, const_err_str, sizeof(err_str)-1);
             int fail = safe_pushstring(L, err_str);
             return fail ? lua_push_error(L): 1;
         }
@@ -505,7 +505,7 @@ lua_consumer_store_offset(struct lua_State *L) {
     if (err) {
         const char *const_err_str = rd_kafka_err2str(err);
         char err_str[512];
-        strncpy(err_str, const_err_str, 512);
+        strncpy(err_str, const_err_str, sizeof(err_str)-1);
         int fail = safe_pushstring(L, err_str);
         return fail ? lua_push_error(L): 1;
     }

--- a/kafka/consumer.c
+++ b/kafka/consumer.c
@@ -570,8 +570,12 @@ lua_consumer_close(struct lua_State *L) {
     rd_kafka_unsubscribe((*consumer_p)->rd_consumer);
 
     // trying to close in background until success
+    int attempts = 5
     while (coio_call(wait_consumer_close, (*consumer_p)->rd_consumer) == -1) {
         // FIXME: maybe send errors to error queue?
+        attempts -= 1;
+        if (attempts == 0) 
+            break;
     }
 
     lua_pushboolean(L, 1);

--- a/kafka/producer.c
+++ b/kafka/producer.c
@@ -375,7 +375,7 @@ lua_producer_produce(struct lua_State *L) {
         if (rd_topic == NULL) {
             const char *const_err_str = rd_kafka_err2str(rd_kafka_errno2err(errno));
             char err_str[512];
-            strncpy(err_str, const_err_str, 512);
+            strncpy(err_str, const_err_str, sizeof(err_str)-1);
             int fail = safe_pushstring(L, err_str);
             return fail ? lua_push_error(L): 1;
         }
@@ -388,7 +388,7 @@ lua_producer_produce(struct lua_State *L) {
     if (rd_kafka_produce(rd_topic, -1, RD_KAFKA_MSG_F_COPY, value, value_len, key, key_len, dr_msg) == -1) {
         const char *const_err_str = rd_kafka_err2str(rd_kafka_errno2err(errno));
         char err_str[512];
-        strncpy(err_str, const_err_str, 512);
+        strncpy(err_str, const_err_str, sizeof(err_str)-1);
         int fail = safe_pushstring(L, err_str);
         return fail ? lua_push_error(L): 1;
     }

--- a/kafka/producer.c
+++ b/kafka/producer.c
@@ -375,7 +375,7 @@ lua_producer_produce(struct lua_State *L) {
         if (rd_topic == NULL) {
             const char *const_err_str = rd_kafka_err2str(rd_kafka_errno2err(errno));
             char err_str[512];
-            strncpy(err_str, const_err_str, sizeof(err_str)-1);
+            strncpy(err_str, const_err_str, sizeof(err_str) - 1);
             int fail = safe_pushstring(L, err_str);
             return fail ? lua_push_error(L): 1;
         }
@@ -388,7 +388,7 @@ lua_producer_produce(struct lua_State *L) {
     if (rd_kafka_produce(rd_topic, -1, RD_KAFKA_MSG_F_COPY, value, value_len, key, key_len, dr_msg) == -1) {
         const char *const_err_str = rd_kafka_err2str(rd_kafka_errno2err(errno));
         char err_str[512];
-        strncpy(err_str, const_err_str, sizeof(err_str)-1);
+        strncpy(err_str, const_err_str, sizeof(err_str) - 1);
         int fail = safe_pushstring(L, err_str);
         return fail ? lua_push_error(L): 1;
     }

--- a/kafka/producer.c
+++ b/kafka/producer.c
@@ -375,7 +375,7 @@ lua_producer_produce(struct lua_State *L) {
         if (rd_topic == NULL) {
             const char *const_err_str = rd_kafka_err2str(rd_kafka_errno2err(errno));
             char err_str[512];
-            strcpy(err_str, const_err_str);
+            strncpy(err_str, const_err_str, 512);
             int fail = safe_pushstring(L, err_str);
             return fail ? lua_push_error(L): 1;
         }
@@ -388,7 +388,7 @@ lua_producer_produce(struct lua_State *L) {
     if (rd_kafka_produce(rd_topic, -1, RD_KAFKA_MSG_F_COPY, value, value_len, key, key_len, dr_msg) == -1) {
         const char *const_err_str = rd_kafka_err2str(rd_kafka_errno2err(errno));
         char err_str[512];
-        strcpy(err_str, const_err_str);
+        strncpy(err_str, const_err_str, 512);
         int fail = safe_pushstring(L, err_str);
         return fail ? lua_push_error(L): 1;
     }

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 pytest
-kafka-python==2.0.0
-aiokafka==0.7.0
-tarantool==0.6.6
+kafka-python==2.0.2
+aiokafka==0.7.2
+tarantool==0.7.1

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -98,7 +98,7 @@ def test_consumer_should_consume_msgs_from_multiple_topics():
 
     message3 = {
         "key": "test1",
-        "value": "test3"
+        "value": "test33"
     }
 
     write_into_kafka("test_multi_consume_1", (message1, message2))
@@ -114,7 +114,7 @@ def test_consumer_should_consume_msgs_from_multiple_topics():
         assert set(*response) == {
             "test1",
             "test2",
-            "test3"
+            "test33"
         }
 
 
@@ -131,7 +131,7 @@ def test_consumer_should_completely_unsubscribe_from_topics():
 
     message3 = {
         "key": "test1",
-        "value": "test3"
+        "value": "test34"
     }
 
     write_into_kafka("test_unsubscribe", (message1, message2))
@@ -170,12 +170,12 @@ def test_consumer_should_partially_unsubscribe_from_topics():
 
     message3 = {
         "key": "test1",
-        "value": "test3"
+        "value": "test35"
     }
 
     message4 = {
         "key": "test1",
-        "value": "test4"
+        "value": "test45"
     }
 
     server = get_server()
@@ -201,7 +201,7 @@ def test_consumer_should_partially_unsubscribe_from_topics():
 
         response = server.call("consumer.consume", [30])
 
-        assert set(*response) == {"test4"}
+        assert set(*response) == {"test45"}
 
 
 def test_consumer_should_log_errors():

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,9 +1,12 @@
+import os
 import time
 import asyncio
 from contextlib import contextmanager
 
 from aiokafka import AIOKafkaProducer
 import tarantool
+
+KAFKA_HOST = os.getenv("KAFKA_HOST", "kafka:9092")
 
 
 def get_server():
@@ -70,7 +73,7 @@ def test_consumer_should_consume_msgs():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_consume_msgs"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_consume_msgs"}):
         server.call("consumer.subscribe", [["test_consume"]])
 
         response = server.call("consumer.consume", [10])
@@ -103,7 +106,7 @@ def test_consumer_should_consume_msgs_from_multiple_topics():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_consume_msgs_from_multiple_topics"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_consume_msgs_from_multiple_topics"}):
         server.call("consumer.subscribe", [["test_multi_consume_1", "test_multi_consume_2"]])
 
         response = server.call("consumer.consume", [10])
@@ -135,7 +138,7 @@ def test_consumer_should_completely_unsubscribe_from_topics():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_completely_unsubscribe_from_topics"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_completely_unsubscribe_from_topics"}):
         server.call("consumer.subscribe", [["test_unsubscribe"]])
 
         response = server.call("consumer.consume", [10])
@@ -177,7 +180,7 @@ def test_consumer_should_partially_unsubscribe_from_topics():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_partially_unsubscribe_from_topics"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_partially_unsubscribe_from_topics"}):
         server.call("consumer.subscribe", [["test_unsub_partially_1", "test_unsub_partially_2"]])
 
         write_into_kafka("test_unsub_partially_1", (message1, ))
@@ -215,7 +218,7 @@ def test_consumer_should_log_errors():
 def test_consumer_should_log_debug():
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"debug": "consumer,cgrp,topic,fetch"}):
+    with create_consumer(server, KAFKA_HOST, {"debug": "consumer,cgrp,topic,fetch"}):
         time.sleep(2)
 
         response = server.call("consumer.get_logs", [])
@@ -226,12 +229,12 @@ def test_consumer_should_log_debug():
 def test_consumer_should_log_rebalances():
     server = get_server()
 
-    with create_consumer(server, "kafka:9092"):
-        time.sleep(2)
+    with create_consumer(server, KAFKA_HOST):
+        time.sleep(5)
 
         server.call("consumer.subscribe", [["test_unsub_partially_1"]])
 
-        time.sleep(10)
+        time.sleep(20)
 
         response = server.call("consumer.get_rebalances", [])
 
@@ -261,7 +264,7 @@ def test_consumer_should_continue_consuming_from_last_committed_offset():
 
     server = get_server()
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_continue_consuming_from_last_committed_offset"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_continue_consuming_from_last_committed_offset"}):
         server.call("consumer.subscribe", [["test_consuming_from_last_committed_offset"]])
 
         write_into_kafka("test_consuming_from_last_committed_offset", (message1, ))
@@ -277,7 +280,7 @@ def test_consumer_should_continue_consuming_from_last_committed_offset():
 
     time.sleep(2)
 
-    with create_consumer(server, "kafka:9092", {"group.id": "should_continue_consuming_from_last_committed_offset"}):
+    with create_consumer(server, KAFKA_HOST, {"group.id": "should_continue_consuming_from_last_committed_offset"}):
         server.call("consumer.subscribe", [["test_consuming_from_last_committed_offset"]])
 
         write_into_kafka("test_consuming_from_last_committed_offset", (message3, ))

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -1,8 +1,11 @@
+import os
 import time
 import asyncio
 
 from aiokafka import AIOKafkaConsumer
 import tarantool
+
+KAFKA_HOST = os.getenv("KAFKA_HOST", "kafka:9092")
 
 
 def get_server():
@@ -18,7 +21,7 @@ def get_server():
 def test_producer_should_produce_msgs():
     server = get_server()
 
-    server.call("producer.create", ["kafka:9092"])
+    server.call("producer.create", [KAFKA_HOST])
 
     server.call("producer.produce", (
         (
@@ -56,7 +59,7 @@ def test_producer_should_produce_msgs():
                 await consumer.stop()
 
         try:
-            await asyncio.wait_for(consume(), 10, loop=loop)
+            await asyncio.wait_for(consume(), 10)
         except asyncio.TimeoutError:
             pass
 
@@ -98,7 +101,7 @@ def test_producer_should_log_errors():
 def test_producer_should_log_debug():
     server = get_server()
 
-    server.call("producer.create", ["kafka:9092", {"debug": "broker,topic,msg"}])
+    server.call("producer.create", [KAFKA_HOST, {"debug": "broker,topic,msg"}])
 
     time.sleep(2)
 


### PR DESCRIPTION
This patch changes a lot of things to be able to enable tests in
CI:
  - Bump librdkafka version to v1.8.2
  - Bump python requirements versions
  - Tune timeouts in tests
  - Drop deprecated option from tests
  - Allow to pass kafka host via env variables
  - Clean input queue for consumer while close