### PR TITLE
disable zstd linking in static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ message("Found OPENSSL version: ${OPENSSL_VERSION}")
 if(STATIC_BUILD)
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/librdkafka/lib/librdkafka.a
-        COMMAND ./configure --enable-ssl --prefix=${CMAKE_BINARY_DIR}/librdkafka
+        COMMAND ./configure --enable-ssl --disable-zstd --prefix=${CMAKE_BINARY_DIR}/librdkafka
         COMMAND make -j
         COMMAND make install
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/librdkafka


### PR DESCRIPTION
It's quite strange but Linux build doesn't require zstd symbols -
it fails only if zstd explicitly enabled.
On OS X behaviour is different. So let's disable zstd compression
for macos static build. Anyway we don't use macos in production.