### PR TITLE
Fix infinity consumer close method

### DIFF
--- a/tests/consumer.lua
+++ b/tests/consumer.lua
@@ -43,7 +43,11 @@ local function create(brokers, additional_opts)
     }
     if additional_opts ~= nil then
         for key, value in pairs(additional_opts) do
-            options[key] = value
+            if value == nil then
+                options[key] = nil
+            else
+                options[key] = value
+            end
         end
     end
     consumer, err = tnt_kafka.Consumer.create({

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
-pytest
+pytest==7.0.0
+pytest-timeout==2.1.0
 kafka-python==2.0.2
 aiokafka==0.7.2
 tarantool==0.7.1

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -4,6 +4,7 @@ import json
 import asyncio
 from contextlib import contextmanager
 
+import pytest
 from aiokafka import AIOKafkaProducer
 import tarantool
 
@@ -354,3 +355,11 @@ def test_consumer_should_continue_consuming_from_last_committed_offset():
             "test3",
             "test4",
         }
+
+
+@pytest.mark.timeout(5)
+def test_consumer_should_be_closed():
+    server = get_server()
+
+    with create_consumer(server, '127.0.0.1:12345', {"group.id": None}):
+        pass


### PR DESCRIPTION
Before this patch, if there is no connection to the broker,
then the close method of consumer could hang while clearing
the message queue due to missing error handling.

Now, if it is impossible to get messages from the queue for a long time,
then the queue stops clearing and the close method ends its work.