### PR TITLE
set a name to kafka threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MY_C_FLAGS}")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${MY_C_FLAGS} -ggdb3")
 
 find_package(Tarantool REQUIRED)
-# Oracle Connector requires fiber_cond API added in 1.7.4-291
-string(REPLACE "-" "." tntver ${TARANTOOL_VERSION})
-if(${tntver} VERSION_LESS 1.7.4.291)
-    message(FATAL_ERROR "Tarantool >= 1.7.4-291 is required")
-endif()
 
 set(STATIC_BUILD "OFF", CACHE BOOL "Link dependencies statically?")
 set(WITH_OPENSSL_1_1 "OFF" CACHE BOOL "Require openssl version >= 1.1?")

--- a/kafka/CMakeLists.txt
+++ b/kafka/CMakeLists.txt
@@ -8,7 +8,8 @@ if (APPLE)
         -undefined suppress -flat_namespace")
 endif(APPLE)
 
-target_link_libraries(tntkafka pthread)
+find_package(Threads REQUIRED)
+target_link_libraries(tntkafka ${CMAKE_THREAD_LIBS_INIT})
 
 target_link_libraries(tntkafka ${RDKAFKA_LIBRARY})
 set_target_properties(tntkafka PROPERTIES PREFIX "" OUTPUT_NAME "tntkafka")

--- a/kafka/common.c
+++ b/kafka/common.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include <lua.h>
 #include <common.h>
 #include <assert.h>
@@ -293,3 +295,16 @@ lua_librdkafka_list_groups(struct lua_State *L, rd_kafka_t *rk, const char *grou
     rd_kafka_group_list_destroy(grplistp);
     return 1;
 }
+
+#ifdef __linux__
+void set_thread_name(pthread_t thread, const char *name) {
+    int rc = pthread_setname_np(thread, name);
+    (void)rc;
+    assert(rc == 0);
+}
+#else
+void set_thread_name(pthread_t thread, const char *name) {
+    (void)thread;
+    (void)name;
+}
+#endif

--- a/kafka/common.h
+++ b/kafka/common.h
@@ -14,6 +14,7 @@
 #include <lualib.h>
 #include <lauxlib.h>
 #include <librdkafka/rdkafka.h>
+#include <pthread.h>
 
 #include <tarantool/module.h>
 
@@ -35,5 +36,7 @@ lua_librdkafka_list_groups(struct lua_State *L, rd_kafka_t *rk, const char *grou
  * Push native lua error with code -3
  */
 int lua_push_error(struct lua_State *L);
+
+void set_thread_name(pthread_t thread, const char *name);
 
 #endif //TNT_KAFKA_COMMON_H

--- a/kafka/init.lua
+++ b/kafka/init.lua
@@ -28,29 +28,34 @@ function Consumer.create(config)
     new._poll_msg_fiber = fiber.create(function()
         new:_poll_msg()
     end)
+    new._poll_msg_fiber:name('kafka_msg_poller')
 
     if config.log_callback ~= nil then
         new._poll_logs_fiber = fiber.create(function()
             new:_poll_logs()
         end)
+        new._poll_logs_fiber:name('kafka_logs_poller')
     end
 
     if config.stats_callback ~= nil then
         new._poll_stats_fiber = fiber.create(function()
             new:_poll_stats()
         end)
+        new._poll_stats_fiber:name('kafka_stats_poller')
     end
 
     if config.error_callback ~= nil then
         new._poll_errors_fiber = fiber.create(function()
             new:_poll_errors()
         end)
+        new._poll_errors_fiber:name('kafka_error_poller')
     end
 
     if config.rebalance_callback ~= nil then
         new._poll_rebalances_fiber = fiber.create(function()
             new:_poll_rebalances()
         end)
+        new._poll_rebalances_fiber:name('kafka_rebalances_poller')
     end
 
     return new, nil

--- a/kafka/producer.c
+++ b/kafka/producer.c
@@ -50,8 +50,7 @@ producer_poll_loop(void *arg) {
 
 static producer_poller_t *
 new_producer_poller(rd_kafka_t *rd_producer) {
-    producer_poller_t *poller = NULL;
-    poller = malloc(sizeof(producer_poller_t));
+    producer_poller_t *poller = malloc(sizeof(producer_poller_t));
     if (poller == NULL)
         return NULL;
 
@@ -61,8 +60,13 @@ new_producer_poller(rd_kafka_t *rd_producer) {
     pthread_mutex_init(&poller->lock, NULL);
     pthread_attr_init(&poller->attr);
     pthread_attr_setdetachstate(&poller->attr, PTHREAD_CREATE_JOINABLE);
-    pthread_create(&poller->thread, &poller->attr, producer_poll_loop, (void *)poller);
+    int rc = pthread_create(&poller->thread, &poller->attr, producer_poll_loop, (void *)poller);
+    if (rc < 0) {
+        free(poller);
+        return NULL;
+    }
 
+    set_thread_name(poller->thread, "kafka_producer");
     return poller;
 }
 


### PR DESCRIPTION
Recently we faced some strange issue in one project. There were a
lot of different records in metrics about threads stats. It was
impossible to understand where all this threads appeared.
This patch adds names to kafka threads. So it will be possible to
count amount of threads that kafka module creates.