### PR TITLE
use pthread_setname_np inside a thread

### DIFF
--- a/kafka/common.c
+++ b/kafka/common.c
@@ -296,15 +296,19 @@ lua_librdkafka_list_groups(struct lua_State *L, rd_kafka_t *rk, const char *grou
     return 1;
 }
 
+void set_thread_name(const char *name)
 #ifdef __linux__
-void set_thread_name(pthread_t thread, const char *name) {
-    int rc = pthread_setname_np(thread, name);
+{
+    int rc = pthread_setname_np(pthread_self(), name);
     (void)rc;
     assert(rc == 0);
 }
+#elif __APPLE__
+{
+    pthread_setname_np(name);
+}
 #else
-void set_thread_name(pthread_t thread, const char *name) {
-    (void)thread;
-    (void)name;
+{
+	(void)name;
 }
 #endif

--- a/kafka/common.h
+++ b/kafka/common.h
@@ -37,6 +37,6 @@ lua_librdkafka_list_groups(struct lua_State *L, rd_kafka_t *rk, const char *grou
  */
 int lua_push_error(struct lua_State *L);
 
-void set_thread_name(pthread_t thread, const char *name);
+void set_thread_name(const char *name);
 
 #endif //TNT_KAFKA_COMMON_H

--- a/kafka/consumer.c
+++ b/kafka/consumer.c
@@ -20,6 +20,8 @@
 
 static void *
 consumer_poll_loop(void *arg) {
+    set_thread_name("kafka_consumer");
+
     consumer_poller_t *poller = arg;
     event_queues_t *event_queues = rd_kafka_opaque(poller->rd_consumer);
     rd_kafka_message_t *rd_msg = NULL;
@@ -103,7 +105,6 @@ new_consumer_poller(rd_kafka_t *rd_consumer) {
         free(poller);
         return NULL;
     }
-    set_thread_name(poller->thread, "kafka_consumer");
 
     return poller;
 }

--- a/kafka/producer.c
+++ b/kafka/producer.c
@@ -19,6 +19,8 @@
 
 static void *
 producer_poll_loop(void *arg) {
+    set_thread_name("kafka_producer");
+
     producer_poller_t *poller = arg;
     int count = 0;
     int should_stop = 0;
@@ -66,7 +68,6 @@ new_producer_poller(rd_kafka_t *rd_producer) {
         return NULL;
     }
 
-    set_thread_name(poller->thread, "kafka_producer");
     return poller;
 }
 


### PR DESCRIPTION
It allows to implement macos version. But main thing:

> pthread_setname_np() internally writes to the thread specific comm file under /proc filesystem: /proc/self/task/[tid]/comm.

So we mustn't to use io directly from TX thread. But we can't do
it from other threads.