### PR TITLE
implement `pause` and `resume` methods

### DIFF
--- a/kafka/CMakeLists.txt
+++ b/kafka/CMakeLists.txt
@@ -10,6 +10,7 @@ endif(APPLE)
 
 find_package(Threads REQUIRED)
 target_link_libraries(tntkafka ${CMAKE_THREAD_LIBS_INIT})
+set_target_properties(tntkafka PROPERTIES C_VISIBILITY_PRESET hidden)
 
 target_link_libraries(tntkafka ${RDKAFKA_LIBRARY})
 set_target_properties(tntkafka PROPERTIES PREFIX "" OUTPUT_NAME "tntkafka")

--- a/kafka/common.h
+++ b/kafka/common.h
@@ -22,9 +22,11 @@ extern const char* const consumer_label;
 extern const char* const consumer_msg_label;
 extern const char* const producer_label;
 
-int lua_librdkafka_version(struct lua_State *L);
+int
+lua_librdkafka_version(struct lua_State *L);
 
-int lua_librdkafka_dump_conf(struct lua_State *L, rd_kafka_t *rk);
+int
+lua_librdkafka_dump_conf(struct lua_State *L, rd_kafka_t *rk);
 
 int
 lua_librdkafka_metadata(struct lua_State *L, rd_kafka_t *rk, rd_kafka_topic_t *only_rkt, int timeout_ms);
@@ -35,8 +37,16 @@ lua_librdkafka_list_groups(struct lua_State *L, rd_kafka_t *rk, const char *grou
 /**
  * Push native lua error with code -3
  */
-int lua_push_error(struct lua_State *L);
+int
+lua_push_error(struct lua_State *L);
 
-void set_thread_name(const char *name);
+void
+set_thread_name(const char *name);
+
+rd_kafka_resp_err_t
+kafka_pause(rd_kafka_t *rk);
+
+rd_kafka_resp_err_t
+kafka_resume(rd_kafka_t *rk);
 
 #endif //TNT_KAFKA_COMMON_H

--- a/kafka/consumer.c
+++ b/kafka/consumer.c
@@ -708,3 +708,29 @@ lua_consumer_list_groups(struct lua_State *L) {
     }
     return 0;
 }
+
+static int
+lua_consumer_call_pause_resume(struct lua_State *L, rd_kafka_resp_err_t (*fun)(rd_kafka_t *rk)) {
+    consumer_t **consumer_p = luaL_checkudata(L, 1, consumer_label);
+    if (consumer_p == NULL || *consumer_p == NULL)
+        return 0;
+
+    if ((*consumer_p)->rd_consumer != NULL) {
+        rd_kafka_resp_err_t err = fun((*consumer_p)->rd_consumer);
+        if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
+            lua_pushstring(L, rd_kafka_err2str(err));
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int
+lua_consumer_pause(struct lua_State *L) {
+    return lua_consumer_call_pause_resume(L, kafka_pause);
+}
+
+int
+lua_consumer_resume(struct lua_State *L) {
+    return lua_consumer_call_pause_resume(L, kafka_resume);
+}

--- a/kafka/consumer.h
+++ b/kafka/consumer.h
@@ -32,34 +32,55 @@ typedef struct {
     consumer_poller_t               *poller;
 } consumer_t;
 
-int lua_consumer_subscribe(struct lua_State *L);
+int
+lua_consumer_subscribe(struct lua_State *L);
 
-int lua_consumer_unsubscribe(struct lua_State *L);
+int
+lua_consumer_unsubscribe(struct lua_State *L);
 
-int lua_consumer_tostring(struct lua_State *L);
+int
+lua_consumer_tostring(struct lua_State *L);
 
-int lua_consumer_poll_msg(struct lua_State *L);
+int
+lua_consumer_poll_msg(struct lua_State *L);
 
-int lua_consumer_poll_logs(struct lua_State *L);
+int
+lua_consumer_poll_logs(struct lua_State *L);
 
-int lua_consumer_poll_stats(struct lua_State *L);
+int
+lua_consumer_poll_stats(struct lua_State *L);
 
-int lua_consumer_poll_errors(struct lua_State *L);
+int
+lua_consumer_poll_errors(struct lua_State *L);
 
-int lua_consumer_poll_rebalances(struct lua_State *L);
+int
+lua_consumer_poll_rebalances(struct lua_State *L);
 
-int lua_consumer_store_offset(struct lua_State *L);
+int
+lua_consumer_store_offset(struct lua_State *L);
 
-int lua_consumer_close(struct lua_State *L);
+int
+lua_consumer_close(struct lua_State *L);
 
-int lua_consumer_destroy(struct lua_State *L);
+int
+lua_consumer_destroy(struct lua_State *L);
 
-int lua_create_consumer(struct lua_State *L);
+int
+lua_create_consumer(struct lua_State *L);
 
-int lua_consumer_dump_conf(struct lua_State *L);
+int
+lua_consumer_dump_conf(struct lua_State *L);
 
-int lua_consumer_metadata(struct lua_State *L);
+int
+lua_consumer_metadata(struct lua_State *L);
 
-int lua_consumer_list_groups(struct lua_State *L);
+int
+lua_consumer_list_groups(struct lua_State *L);
+
+int
+lua_consumer_pause(struct lua_State *L);
+
+int
+lua_consumer_resume(struct lua_State *L);
 
 #endif //TNT_KAFKA_CONSUMER_H

--- a/kafka/init.lua
+++ b/kafka/init.lua
@@ -203,6 +203,14 @@ function Consumer:store_offset(message)
     return self._consumer:store_offset(message)
 end
 
+function Consumer:pause()
+    return self._consumer:pause()
+end
+
+function Consumer:resume()
+    return self._consumer:resume()
+end
+
 function Consumer:dump_conf()
     if self._consumer == nil then
         return

--- a/kafka/producer.h
+++ b/kafka/producer.h
@@ -30,9 +30,11 @@ typedef struct {
 
 producer_topics_t *new_producer_topics(int32_t capacity);
 
-int add_producer_topics(producer_topics_t *topics, rd_kafka_topic_t *element);
+int
+add_producer_topics(producer_topics_t *topics, rd_kafka_topic_t *element);
 
-void destroy_producer_topics(producer_topics_t *topics);
+void
+destroy_producer_topics(producer_topics_t *topics);
 
 typedef struct {
     rd_kafka_t        *rd_producer;
@@ -41,28 +43,40 @@ typedef struct {
     producer_poller_t *poller;
 } producer_t;
 
-int lua_producer_tostring(struct lua_State *L);
+int
+lua_producer_tostring(struct lua_State *L);
 
-int lua_producer_msg_delivery_poll(struct lua_State *L);
+int
+lua_producer_msg_delivery_poll(struct lua_State *L);
 
-int lua_producer_poll_logs(struct lua_State *L);
+int
+lua_producer_poll_logs(struct lua_State *L);
 
-int lua_producer_poll_stats(struct lua_State *L);
+int
+lua_producer_poll_stats(struct lua_State *L);
 
-int lua_producer_poll_errors(struct lua_State *L);
+int
+lua_producer_poll_errors(struct lua_State *L);
 
-int lua_producer_produce(struct lua_State *L);
+int
+lua_producer_produce(struct lua_State *L);
 
-int lua_producer_close(struct lua_State *L);
+int
+lua_producer_close(struct lua_State *L);
 
-int lua_create_producer(struct lua_State *L);
+int
+lua_create_producer(struct lua_State *L);
 
-int lua_producer_destroy(struct lua_State *L);
+int
+lua_producer_destroy(struct lua_State *L);
 
-int lua_producer_dump_conf(struct lua_State *L);
+int
+lua_producer_dump_conf(struct lua_State *L);
 
-int lua_producer_metadata(struct lua_State *L);
+int
+lua_producer_metadata(struct lua_State *L);
 
-int lua_producer_list_groups(struct lua_State *L);
+int
+lua_producer_list_groups(struct lua_State *L);
 
 #endif //TNT_KAFKA_PRODUCER_H

--- a/kafka/tnt_kafka.c
+++ b/kafka/tnt_kafka.c
@@ -28,6 +28,8 @@ luaopen_kafka_tntkafka(lua_State *L) {
             {"dump_conf", lua_consumer_dump_conf},
             {"metadata", lua_consumer_metadata},
             {"list_groups", lua_consumer_list_groups},
+            {"pause", lua_consumer_pause},
+            {"resume", lua_consumer_resume},
             {"close", lua_consumer_close},
             {"destroy", lua_consumer_destroy},
             {"__tostring", lua_consumer_tostring},

--- a/kafka/tnt_kafka.c
+++ b/kafka/tnt_kafka.c
@@ -14,7 +14,7 @@
  * Entry point
  */
 
-LUA_API int
+LUA_API int __attribute__ ((visibility("default")))
 luaopen_kafka_tntkafka(lua_State *L) {
     static const struct luaL_Reg consumer_methods [] = {
             {"subscribe", lua_consumer_subscribe},

--- a/tests/consumer.lua
+++ b/tests/consumer.lua
@@ -160,6 +160,14 @@ local function list_groups(timeout_ms)
     return consumer:list_groups({timeout_ms = timeout_ms})
 end
 
+local function pause()
+    return consumer:pause()
+end
+
+local function resume()
+    return consumer:resume()
+end
+
 local function close()
     log.info("closing consumer")
     local _, err = consumer:close()
@@ -183,4 +191,6 @@ return {
     dump_conf = dump_conf,
     metadata = metadata,
     list_groups = list_groups,
+    pause = pause,
+    resume = resume,
 }


### PR DESCRIPTION
This patch adds a ways to stop pause and resume of consumers and
producers.