### PR TITLE
build: fix typos in CMakeLists.txt

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         tarantool:
-          - '2.8'
+          - '2.10'
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: tarantool/setup-tarantool@v1
         with:
-          tarantool-version: '2.8'
+          tarantool-version: '2.10'
       # Make a release
       - run: echo TAG=${GITHUB_REF##*/} >> $GITHUB_ENV
       - run: tarantoolctl rocks new_version --tag ${{ env.TAG }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${MY_C_FLAGS} -ggdb3")
 
 find_package(Tarantool REQUIRED)
 
-set(STATIC_BUILD "OFF", CACHE BOOL "Link dependencies statically?")
+set(STATIC_BUILD "OFF" CACHE BOOL "Link dependencies statically?")
 set(WITH_OPENSSL_1_1 "OFF" CACHE BOOL "Require openssl version >= 1.1?")
 
 if (WITH_OPENSSL_1_1)
@@ -43,8 +43,7 @@ if(STATIC_BUILD)
 
     set(RDKAFKA_LIBRARY ${RDKAFKA_LIBRARY} librdkafka_static)
 else()
-    set(RDKAFKA_FIND_REQUIRED ON)
-    find_package(RdKafka)
+    find_package(RDKAFKA REQUIRED)
     # Link RdKafka transitive dependencies manually
     set(RDKAFKA_LIBRARY ${RDKAFKA_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
 endif()


### PR DESCRIPTION
  - Redundant comma (that always forces static build)
  - Incorrect name in find_package (should be RDKAFKA instead of
    RdKafka).