### PR TITLE
fix: message deallocation in consumer queue

### DIFF
--- a/kafka/callbacks.c
+++ b/kafka/callbacks.c
@@ -10,6 +10,7 @@
 #include <librdkafka/rdkafka.h>
 
 #include <common.h>
+#include <consumer_msg.h>
 #include <queue.h>
 #include <callbacks.h>
 
@@ -334,12 +335,12 @@ new_event_queues() {
 void
 destroy_event_queues(struct lua_State *L, event_queues_t *event_queues) {
     if (event_queues->consume_queue != NULL) {
-        rd_kafka_message_t *msg = NULL;
+        msg_t *msg = NULL;
         while (true) {
             msg = queue_pop(event_queues->consume_queue);
             if (msg == NULL)
                 break;
-            rd_kafka_message_destroy(msg);
+            destroy_consumer_msg(msg);
         }
         destroy_queue(event_queues->consume_queue);
     }


### PR DESCRIPTION
Previously the library crashed when we try to close the non-empty consumer queue.
```
1  0xe3448a in crash_collect+1162
2  0xe33eeb in crash_signal_cb+283
3  0x7ff0581a2630 in __restore_rt+0
4  0x7ff05069ac09 in rd_kafka_op_destroy+25
5  0x7ff0554b5bf2 in destroy_event_queues+50
6  0x7ff0554b7050 in lua_consumer_destroy+192
7  0xf403b7 in lj_BC_FUNCC+70
8  0xf662ba in lua_pcall+3146
9  0xdefda3 in luaT_call+35
10 0xde1ba7 in lua_fiber_run_f+247
11 0x77271a in fiber_cxx_invoke(int (*)(__va_list_tag*), __va_list_tag*)+26 12 0xe4cbc3 in fiber_loop+323
13 0x1a186ec in coro_init+268
```
The problem was in the fact that we expected the wrong type of the messages in `destroy_event_queues()` function while consumer queue deallocation. At the moment `consumer_poll_loop()` function fetches librdkafka messages from Kafka, repacks them to the custom `msg_t` format and pushes to the consumer queue. But when we destroyed the consumer with any messages in this queue, we treated them as librdkafka messages, not like custom ones. That missing is fixed in the current commit.