### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,17 @@ on:
   workflow_dispatch: 
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'kafka'
+          rock-make-opts: 'STATIC_BUILD=ON'
+
   publish-scm-1:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
@@ -17,6 +28,7 @@ jobs:
 
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: version-check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/kafka/CMakeLists.txt
+++ b/kafka/CMakeLists.txt
@@ -16,4 +16,4 @@ target_link_libraries(tntkafka ${RDKAFKA_LIBRARY})
 set_target_properties(tntkafka PROPERTIES PREFIX "" OUTPUT_NAME "tntkafka")
 
 install(TARGETS tntkafka LIBRARY DESTINATION ${TARANTOOL_INSTALL_LIBDIR}/kafka)
-install(FILES init.lua DESTINATION ${TARANTOOL_INSTALL_LUADIR}/kafka)
+install(FILES init.lua version.lua DESTINATION ${TARANTOOL_INSTALL_LUADIR}/kafka)

--- a/kafka/init.lua
+++ b/kafka/init.lua
@@ -471,4 +471,5 @@ return {
     Consumer = Consumer,
     Producer = Producer,
     _LIBRDKAFKA = tnt_kafka.librdkafka_version(),
+    _VERSION = require('kafka.version'),
 }

--- a/kafka/version.lua
+++ b/kafka/version.lua
@@ -1,0 +1,4 @@
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+
+return '1.6.5'


### PR DESCRIPTION
Add versioning support, now the module api has `_VERSION` hardcoded variable. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204